### PR TITLE
Add slave ID support for Modbus TCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The width (32) needs to be 32 in any case. It defines the size of the single ele
 The device mapping file syntax is as follows:
 
     test1 (modbus:168.1.1.1?type=tcp&map=device.map&port=502)
-    test2 (modbus:myserver?type=tcp&map=device.map&port=502)
+    test2 (modbus:myserver?type=tcp&map=device.map&port=502&slaveid=2)
     test3 (modbus:/dev/ttyUSB0?type=rtu&map=device.map&parity=N&baud=115200&data_bits=8&stop_bits=1)
 
 As can be seen in the example above two types of modbus communication are supported:
@@ -26,8 +26,10 @@ Both offer different additional parameters. If no parameters are given the follo
     baud = 115200
     data bits = 8
     stop bits = 1 (other allowed value is 2)
+    slaveid = 1
 * tcp: 
     port = 502
+    slaveid = 255
 
 SDM URI is only supported using default settings as listed above:
     

--- a/src/ModbusBackend.cc
+++ b/src/ModbusBackend.cc
@@ -119,8 +119,9 @@ namespace ChimeraTK {
       if(parameters["port"].empty()) {
         parameters["port"] = std::to_string(MODBUS_TCP_DEFAULT_PORT);
       }
-      // 255 is default slave ID for TCP - see MODBUS_TCP_SLAVE in libmodbus
-      if(parameters["slaveid"].empty()) parameters["slaveid"] = "255";
+      if(parameters["slaveid"].empty()) {
+        parameters["slaveid"] = std::to_string(MODBUS_TCP_SLAVE);
+      }
     }
     else {
       if(parameters["baud"].empty()) parameters["baud"] = "115200";

--- a/src/ModbusBackend.cc
+++ b/src/ModbusBackend.cc
@@ -123,6 +123,7 @@ namespace ChimeraTK {
       if(parameters["slaveid"].empty()) parameters["slaveid"] = "255";
     }
     else {
+      if(parameters["baud"].empty()) parameters["baud"] = "115200";
       if(parameters["parity"].empty()) parameters["parity"] = "N";
       if(parameters["databits"].empty()) parameters["databits"] = "8";
       if(parameters["stopbits"].empty()) parameters["stopbits"] = "1";

--- a/src/ModbusBackend.cc
+++ b/src/ModbusBackend.cc
@@ -63,11 +63,13 @@ namespace ChimeraTK {
     else {
       _ctx = modbus_new_rtu(_address.c_str(), std::stoi(_parameters["baud"]), _parameters["parity"].c_str()[0],
           std::stoi(_parameters["databits"]), std::stoi(_parameters["stopbits"]));
-      modbus_set_slave(_ctx, std::stoi(_parameters["slaveid"]));
     }
     if(_ctx == NULL) {
       throw ChimeraTK::runtime_error(
           std::string("modbus::Backend: Unable to allocate libmodbus context: ") + modbus_strerror(errno));
+    }
+    if(modbus_set_slave(_ctx, std::stoi(_parameters["slaveid"])) < 0) {
+      throw ChimeraTK::runtime_error(std::string("modbus::Backend: Set slave ID failed: ") + modbus_strerror(errno));
     }
     if(modbus_connect(_ctx) == -1) {
       throw ChimeraTK::runtime_error(std::string("modbus::Backend: Connection failed: ") + modbus_strerror(errno));
@@ -117,6 +119,8 @@ namespace ChimeraTK {
       if(parameters["port"].empty()) {
         parameters["port"] = std::to_string(MODBUS_TCP_DEFAULT_PORT);
       }
+      // 255 is default slave ID for TCP - see MODBUS_TCP_SLAVE in libmodbus
+      if(parameters["slaveid"].empty()) parameters["slaveid"] = "255";
     }
     else {
       if(parameters["parity"].empty()) parameters["parity"] = "N";


### PR DESCRIPTION
Use case is to address different Modbus RTU units behind a ethernet-to-485 gateway. Default of 255 makes sure that the behavior is unchanged if `slaveid` parameter is not given for a Modbus TCP connection.