### PR TITLE
Enable merge requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The mapping is done using the same parser as ChimeraTK's pcie backend. Since Mod
 Here 2 elements are read starting from address 18 (register 9). The total resulting length is 4 byte (2 times 16 bits). 
 The width (32) needs to be 32 in any case. It defines the size of the single elements used by the backend, which is 32 because `int32_t` is used. The bar information (3) is used either read holding registers (`bar=3`) or to read input registers (`bar=4`). The holding registers and input registers have different historical meaning, but nowadays it’s more common to use holding registers only. The number of fractional bits (0) and signed/unsigned flag (0) is not used in the backend, but it is used e.g. by Qthardmon to interprete the data read from the device. Since in most cases it will be intepreted wrong anyway (see remark below) it does not matter what is set. Finally, the access right (RO) is set. For more details see the [MapFileParser.cpp](https://github.com/ChimeraTK/DeviceAccess/blob/master/fileparsers/src/MapFileParser.cpp).
 
+Reads/writes of consecutive registers can be merged into single multi-register accesses. To disable this (e.g. for broken Modbus servers), the parameter `disableMerging` can be set.
+
 The device mapping file syntax is as follows:
 
     test1 (modbus:168.1.1.1?type=tcp&map=device.map&port=502)
@@ -27,9 +29,11 @@ Both offer different additional parameters. If no parameters are given the follo
     data bits = 8
     stop bits = 1 (other allowed value is 2)
     slaveid = 1
+    disableMerging = 0
 * tcp: 
     port = 502
     slaveid = 255
+    disableMerging = 0
 
 SDM URI is only supported using default settings as listed above:
     

--- a/include/ModbusBackend.h
+++ b/include/ModbusBackend.h
@@ -36,8 +36,7 @@ namespace ChimeraTK {
 
     void open() override;
     void close() override;
-    //\ToDo: Check if it is possible/works. For now just do not allow merge requests.
-    bool canMergeRequests() const override { return false; }
+    bool canMergeRequests() const override { return true; }
 
     void read(uint64_t bar, uint64_t address, int32_t* data, size_t sizeInBytes) override;
     void write(uint64_t bar, uint64_t address, int32_t const* data, size_t sizeInBytes) override;

--- a/include/ModbusBackend.h
+++ b/include/ModbusBackend.h
@@ -36,7 +36,7 @@ namespace ChimeraTK {
 
     void open() override;
     void close() override;
-    bool canMergeRequests() const override { return true; }
+    bool canMergeRequests() const override { return _mergingEnabled; }
 
     void read(uint64_t bar, uint64_t address, int32_t* data, size_t sizeInBytes) override;
     void write(uint64_t bar, uint64_t address, int32_t const* data, size_t sizeInBytes) override;
@@ -65,6 +65,7 @@ namespace ChimeraTK {
     std::map<std::string, std::string> _parameters;
     ModbusType _type;
     std::atomic<bool> _hasException = {false};
+    bool _mergingEnabled = true;
   };
 } // namespace ChimeraTK
 

--- a/src/ModbusBackend.cc
+++ b/src/ModbusBackend.cc
@@ -80,6 +80,10 @@ namespace ChimeraTK {
     std::cout << "modbus::Backend: Type is: " << _type << std::endl;
 
 #endif
+    auto disable_merging_str = _parameters.find("disableMerging");
+    if(disable_merging_str != _parameters.end()) {
+      _mergingEnabled = (std::stoi(disable_merging_str->second) == 0);
+    }
     _opened = true;
     _hasException = false;
   }


### PR DESCRIPTION
I need transfer merging for my current project, both for efficiency and consistency reasons (data structures spanning across multiple Modbus registers).

The merging is completely handled in DeviceAccess / NumericAddressedBackend, so this backend implementation doesn't have to do any other work other than to enable it.
I tested it with a Modbus server and it works as expected.

Since the user has to build a TransferGroup explicitly in order to use it, just enabling it should not change any behavior in existing projects using this backend.

Fixes #3