### PR TITLE
Set correct transfer alignment

### DIFF
--- a/include/ModbusBackend.h
+++ b/include/ModbusBackend.h
@@ -37,6 +37,8 @@ namespace ChimeraTK {
     void open() override;
     void close() override;
     bool canMergeRequests() const override { return _mergingEnabled; }
+    // Modbus registers are always 16 bit wide
+    size_t minimumTransferAlignment() const override { return 2; }
 
     void read(uint64_t bar, uint64_t address, int32_t* data, size_t sizeInBytes) override;
     void write(uint64_t bar, uint64_t address, int32_t const* data, size_t sizeInBytes) override;


### PR DESCRIPTION
Since we can't access fractions of a Modbus register (and `read()` / `write()` will divide addresses and length by 2 anyway), we should set the minimum alignment to 2 bytes.