### PR TITLE
fix: do not link against BOOST test library

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(Boost COMPONENTS unit_test_framework REQUIRED)
 
 add_executable(testModbus ${library_sources} testModbus.C)
-target_link_libraries(testModbus PUBLIC ChimeraTK::ChimeraTK-DeviceAccess PUBLIC ${Boost_LIBRARIES} PRIVATE ${MODBUS})
+target_link_libraries(testModbus PUBLIC ChimeraTK::ChimeraTK-DeviceAccess PRIVATE ${MODBUS})
 add_test(testModbus testModbus)
 
 file(COPY dummy.map DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
This is probably responsible for a double free corruption in the test.