### PR TITLE
fix: exception state might be fluctuating

### DIFF
--- a/src/ModbusBackend.cc
+++ b/src/ModbusBackend.cc
@@ -75,6 +75,7 @@ namespace ChimeraTK {
         if(error == EINPROGRESS) error = ECONNREFUSED;
         auto message = std::string("ModbusBackend: Connection failed: ") + modbus_strerror(error);
         setException(message);
+        closeConnection();
         throw ChimeraTK::runtime_error(message);
       }
     }


### PR DESCRIPTION
Background: setException() will call closeConnection() only if there was
no exception previously. Since an unsuccessful attempt to open() will
create a _ctx which is then not destroyed again if there was already a
previous exception, the next call to open() will skip the creation of
a new _ctx and directly move on to setOpenedAndClearException(). If also
there is no _lastFailedAddress (because the device was never
successfully opened), the second call to open() will then succeed, which
of course will cause an exception on the next read() operation.

This behaviour can cause an endless recover-failure loop in
ApplicationCore, spamming log files and potentially confusing people.