### PR TITLE
make modus_mutex a data member of the backend + address linter warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ include(cmake/set_default_build_to_release.cmake)
 include(cmake/set_default_flags.cmake)
 include(cmake/enable_code_coverage_report.cmake)
 include(cmake/enable_code_style_check.cmake)
+include(cmake/add_linter_target.cmake)
 
 find_library(MODBUS libmodbus NAMES libmodbus.so)
 

--- a/include/ModbusBackend.h
+++ b/include/ModbusBackend.h
@@ -59,6 +59,9 @@ namespace ChimeraTK {
     void setExceptionImpl() noexcept override;
 
    private:
+    // governs access to _ctx
+    std::mutex _modbus_mutex;
+
     modbus_t* _ctx{nullptr};
     std::string _address;
     std::map<std::string, std::string> _parameters;

--- a/src/ModbusBackend.cc
+++ b/src/ModbusBackend.cc
@@ -12,8 +12,6 @@
 #include <ChimeraTK/BackendFactory.h>
 #include <ChimeraTK/DeviceAccessVersion.h>
 
-#include <bitset>
-
 // You have to define an "extern C" function with this signature. It has to return
 // CHIMERATK_DEVICEACCESS_VERSION for version checking when the library is loaded
 // at run time. This function is used to determine that this is a valid DeviceAcces
@@ -38,8 +36,8 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   ModbusBackend::ModbusBackend(std::string address, ModbusType type, std::map<std::string, std::string> parameters)
-  : NumericAddressedBackend(parameters["map"]), _ctx(nullptr), _address(std::move(address)),
-    _parameters(std::move(parameters)), _type(type) {
+  : NumericAddressedBackend(parameters["map"]), _address(std::move(address)), _parameters(std::move(parameters)),
+    _type(type) {
     _opened = false;
 
     auto disable_merging_str = _parameters.find("disableMerging");
@@ -73,7 +71,9 @@ namespace ChimeraTK {
         // many log messages e.g. in ApplicationCore and hence is here "filtered". EINPROGRESS is anyway a bit
         // misleading in this context and hence is replaced with ECONNREFUSED.
         auto error = errno;
-        if(error == EINPROGRESS) error = ECONNREFUSED;
+        if(error == EINPROGRESS) {
+          error = ECONNREFUSED;
+        }
         auto message = std::string("ModbusBackend: Connection failed: ") + modbus_strerror(error);
         setException(message);
         lock.unlock();
@@ -159,11 +159,21 @@ namespace ChimeraTK {
       }
     }
     else {
-      if(parameters["baud"].empty()) parameters["baud"] = "115200";
-      if(parameters["parity"].empty()) parameters["parity"] = "N";
-      if(parameters["databits"].empty()) parameters["databits"] = "8";
-      if(parameters["stopbits"].empty()) parameters["stopbits"] = "1";
-      if(parameters["slaveid"].empty()) parameters["slaveid"] = "1";
+      if(parameters["baud"].empty()) {
+        parameters["baud"] = "115200";
+      }
+      if(parameters["parity"].empty()) {
+        parameters["parity"] = "N";
+      }
+      if(parameters["databits"].empty()) {
+        parameters["databits"] = "8";
+      }
+      if(parameters["stopbits"].empty()) {
+        parameters["stopbits"] = "1";
+      }
+      if(parameters["slaveid"].empty()) {
+        parameters["slaveid"] = "1";
+      }
     }
     return boost::shared_ptr<DeviceBackend>(new ModbusBackend(std::move(address), type, parameters));
   }
@@ -191,7 +201,9 @@ namespace ChimeraTK {
       address /= 2;
       length /= 2;
     }
-    if(length == 0) length = 1;
+    if(length == 0) {
+      length = 1;
+    }
 
     int rc;
     if(bar == 0) {
@@ -211,7 +223,7 @@ namespace ChimeraTK {
           "Bar number " + std::to_string((int)bar) + " is not supported by the ModbusBackend.");
     }
 
-    if(rc != (int)length) {
+    if(rc != length) {
       _lastFailedAddress = {bar, addressInBytes};
       std::string modbusError;
       if(rc == -1) {
@@ -248,7 +260,9 @@ namespace ChimeraTK {
       address /= 2;
       length /= 2;
     }
-    if(length == 0) length = 1;
+    if(length == 0) {
+      length = 1;
+    }
 
     int rc;
     if(bar == 0) {
@@ -272,7 +286,7 @@ namespace ChimeraTK {
       throw ChimeraTK::runtime_error(
           "Writing bar number " + std::to_string((int)bar) + " is not supported by the ModbusBackend.");
     }
-    if(rc != (int)length) {
+    if(rc != length) {
       _lastFailedAddress = {bar, addressInBytes};
       std::string modbusError;
       if(rc == -1) {

--- a/src/ModbusBackend.cc
+++ b/src/ModbusBackend.cc
@@ -25,7 +25,6 @@ const char* deviceAccessVersionUsedToCompile() {
 }
 
 namespace ChimeraTK {
-  static std::mutex modbus_mutex;
 
   /********************************************************************************************************************/
 
@@ -52,7 +51,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   void ModbusBackend::open() {
-    std::unique_lock<std::mutex> lock(modbus_mutex);
+    std::unique_lock<std::mutex> lock(_modbus_mutex);
 
     if(_ctx == nullptr) {
       if(_type == tcp) {
@@ -112,7 +111,7 @@ namespace ChimeraTK {
   /********************************************************************************************************************/
 
   void ModbusBackend::closeConnection() {
-    std::lock_guard<std::mutex> lock(modbus_mutex);
+    std::lock_guard<std::mutex> lock(_modbus_mutex);
     if(_ctx != nullptr) {
       modbus_close(_ctx);
       modbus_free(_ctx);
@@ -182,7 +181,7 @@ namespace ChimeraTK {
     }
     auto length = static_cast<int>(sizeInBytes);
 
-    std::lock_guard<std::mutex> lock(modbus_mutex);
+    std::lock_guard<std::mutex> lock(_modbus_mutex);
     checkActiveException();
     assert(_ctx != nullptr);
 
@@ -239,7 +238,7 @@ namespace ChimeraTK {
     }
     auto length = static_cast<int>(sizeInBytes);
 
-    std::lock_guard<std::mutex> lock(modbus_mutex);
+    std::lock_guard<std::mutex> lock(_modbus_mutex);
     checkActiveException();
     assert(_ctx != nullptr);
 


### PR DESCRIPTION
Note: The two commits are entirely unrelated, and "[chore: make modus_mutex a data member of the backend](https://github.com/ChimeraTK/DeviceAccess-ModbusBackend/commit/03f4b9698a3ae44147cb307c443ac5e63aa94f7f)" is the more important one for this review. I recommend reviewing them separately.